### PR TITLE
including HTTP in the src attribute

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,9 +1,9 @@
 <html>
 <head>
 <title>Bounding box annotator demo</title>
-<link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/themes/smoothness/jquery-ui.css" />
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.js"></script>
+<link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/themes/smoothness/jquery-ui.css" />
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.js"></script>
 <script src="bbox_annotator.js"></script>
 </head>
 <body>


### PR DESCRIPTION
The code wouldn't work if the `http` was not included in the `src` attribute. I made the changes to make it work.